### PR TITLE
Fixed outdoor lamp errors

### DIFF
--- a/1.3/Source/RimEffectExtendedCut/Comps/CompPowerOutDoorLamp.cs
+++ b/1.3/Source/RimEffectExtendedCut/Comps/CompPowerOutDoorLamp.cs
@@ -100,7 +100,7 @@ namespace RimEffectExtendedCut
                 {
 					if (compGlowerExtended.compGlower != null)
 					{
-						compGlowerExtended.RemoveGlower();
+						compGlowerExtended.RemoveGlower(this.parent.Map);
 					}
 				}
 				else
@@ -109,7 +109,7 @@ namespace RimEffectExtendedCut
 					{
 						if (compGlowerExtended.compGlower != null)
 						{
-							compGlowerExtended.RemoveGlower();
+							compGlowerExtended.RemoveGlower(this.parent.Map);
 						}
 					}
 					else if (compGlowerExtended.compGlower == null)


### PR DESCRIPTION
CompGlowerExtended.RemoveGlower now requires the Map parameter, which it originally didn't require. This fixes it by providing it.